### PR TITLE
Change behavior spider.get modules

### DIFF
--- a/docs/api/lmod.main.rst
+++ b/docs/api/lmod.main.rst
@@ -1,7 +1,0 @@
-lmod.main module
-================
-
-.. automodule:: lmod.main
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/api/lmod.menu.rst
+++ b/docs/api/lmod.menu.rst
@@ -1,7 +1,0 @@
-lmod.menu module
-================
-
-.. automodule:: lmod.menu
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/api/lmod.rst
+++ b/docs/api/lmod.rst
@@ -6,8 +6,6 @@ Submodules
 
 .. toctree::
 
-   lmod.main
-   lmod.menu
    lmod.module
    lmod.moduleloadtest
    lmod.spider

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,9 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
 
+from lmod import LMODULE_VERSION
 from sphinx.ext.apidoc import main as sphinx_apidoc
 
 # -- Project information -----------------------------------------------------
@@ -23,7 +24,7 @@ copyright = "2020, Shahzeb Siddiqui"
 author = "Shahzeb Siddiqui"
 
 # The full version, including alpha/beta/rc tags
-version = "0.1"
+version = LMODULE_VERSION
 release = "beta"
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,9 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
 
 from sphinx.ext.apidoc import main as sphinx_apidoc
 

--- a/docs/moduleloadtest.rst
+++ b/docs/moduleloadtest.rst
@@ -13,15 +13,17 @@ To test all modules set by MODULEPATH you can run the invoke ``ModuleLoadTest()`
 .. code-block:: python
 
     >>> a = ModuleLoadTest()
+    >>> a = ModuleLoadTest()
     Testing the Following Module Trees: /mxg-hpc/users/ssi29/easybuild-HMNS/modules/all/Core:/mxg-hpc/users/ssi29/spack/modules/linux-rhel7-x86_64/Core:/mxg-hpc/users/ssi29/easybuild/modules/all:/etc/modulefiles:/usr/share/modulefiles:/usr/share/modulefiles/Linux:/usr/share/modulefiles/Core:/usr/share/lmod/lmod/modulefiles/Core
     ________________________________________________________________________________
-    PASSED -  Module Name: Anaconda3/5.3.0
-    PASSED -  Module Name: Autoconf/2.69-GCCcore-6.4.0
-    PASSED -  Module Name: Autoconf/2.69-GCCcore-8.3.0
-    PASSED -  Module Name: Automake/1.15.1-GCCcore-6.4.0
-    PASSED -  Module Name: Automake/1.16.1-GCCcore-8.3.0
-    PASSED -  Module Name: Autotools/20170619-GCCcore-6.4.0
-    PASSED -  Module Name: Autotools/20180311-GCCcore-8.3.0
+    PASSED -  Module Name: Anaconda3/5.3.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Anaconda3/5.3.0.lua )
+    PASSED -  Module Name: Autoconf/2.69-GCCcore-8.3.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Autoconf/2.69-GCCcore-8.3.0.lua )
+    PASSED -  Module Name: Autoconf/2.69-GCCcore-6.4.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Autoconf/2.69-GCCcore-6.4.0.lua )
+    PASSED -  Module Name: Automake/1.16.1-GCCcore-8.3.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Automake/1.16.1-GCCcore-8.3.0.lua )
+    PASSED -  Module Name: Automake/1.15.1-GCCcore-6.4.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Automake/1.15.1-GCCcore-6.4.0.lua )
+    PASSED -  Module Name: Autotools/20170619-GCCcore-6.4.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Autotools/20170619-GCCcore-6.4.0.lua )
+    PASSED -  Module Name: Autotools/20180311-GCCcore-8.3.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Autotools/20180311-GCCcore-8.3.0.lua )
+
 
 Tweak Number of Tests
 -----------------------
@@ -32,9 +34,10 @@ We can control how many tests to run by passing ``count`` argument. Shown below 
     >>> b = ModuleLoadTest(count=3)
     Testing the Following Module Trees: /mxg-hpc/users/ssi29/easybuild-HMNS/modules/all/Core:/mxg-hpc/users/ssi29/spack/modules/linux-rhel7-x86_64/Core:/mxg-hpc/users/ssi29/easybuild/modules/all:/etc/modulefiles:/usr/share/modulefiles:/usr/share/modulefiles/Linux:/usr/share/modulefiles/Core:/usr/share/lmod/lmod/modulefiles/Core
     ________________________________________________________________________________
-    PASSED -  Module Name: Anaconda3/5.3.0
-    PASSED -  Module Name: Autoconf/2.69-GCCcore-6.4.0
-    PASSED -  Module Name: Autoconf/2.69-GCCcore-8.3.0
+    PASSED -  Module Name: Anaconda3/5.3.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Anaconda3/5.3.0.lua )
+    PASSED -  Module Name: Autoconf/2.69-GCCcore-8.3.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Autoconf/2.69-GCCcore-8.3.0.lua )
+    PASSED -  Module Name: Autoconf/2.69-GCCcore-6.4.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Autoconf/2.69-GCCcore-6.4.0.lua )
+
 
 We can configure which module trees to test by specifying the ``tree`` argument and enable debug mode by passing ``debug=True``.
 
@@ -45,10 +48,11 @@ We can configure which module trees to test by specifying the ``tree`` argument 
     ________________________________________________________________________________
     [DEBUG] Executing module command: module purge && module load lmod
     [DEBUG] Return Code: 0
-    PASSED -  Module Name: lmod
+    PASSED -  Module Name: lmod ( modulefile=/usr/share/lmod/lmod/modulefiles/Core/lmod.lua )
     [DEBUG] Executing module command: module purge && module load settarg
     [DEBUG] Return Code: 0
-    PASSED -  Module Name: settarg
+    PASSED -  Module Name: settarg ( modulefile=/usr/share/lmod/lmod/modulefiles/Core/settarg.lua )
+
 
 If you would like to specify  more than one tree you can specify them separating by a colon ``:`` character.
 
@@ -65,10 +69,11 @@ but this can be disabled by passing ``purge=False``.
     ________________________________________________________________________________
     [DEBUG] Executing module command: module load lmod
     [DEBUG] Return Code: 0
-    PASSED -  Module Name: lmod
+    PASSED -  Module Name: lmod ( modulefile=/usr/share/lmod/lmod/modulefiles/Core/lmod.lua )
     [DEBUG] Executing module command: module load settarg
     [DEBUG] Return Code: 0
-    PASSED -  Module Name: settarg
+    PASSED -  Module Name: settarg ( modulefile=/usr/share/lmod/lmod/modulefiles/Core/settarg.lua )
+
 
 If you want to force purge modules, then pass in the ``force=True``. You may get unexpected result depending on your site
 configuration.
@@ -80,12 +85,10 @@ configuration.
     ________________________________________________________________________________
     [DEBUG] Executing module command: module --force purge &&  module load lmod
     [DEBUG] Return Code: 0
-    PASSED -  Module Name: lmod
+    PASSED -  Module Name: lmod ( modulefile=/usr/share/lmod/lmod/modulefiles/Core/lmod.lua )
     [DEBUG] Executing module command: module --force purge &&  module load settarg
     [DEBUG] Return Code: 0
-    PASSED -  Module Name: settarg
-
-
+    PASSED -  Module Name: settarg ( modulefile=/usr/share/lmod/lmod/modulefiles/Core/settarg.lua )
 
 Filtering Modules
 ------------------
@@ -105,18 +108,19 @@ To filter by module names you can pass ``name`` option which is a list of softwa
     >>> g = ModuleLoadTest("/mxg-hpc/users/ssi29/easybuild/modules/all",name=["Automake","Bison"])
     Testing the Following Module Trees: /mxg-hpc/users/ssi29/easybuild/modules/all
     ________________________________________________________________________________
-    PASSED -  Module Name: Automake/1.15.1-GCCcore-6.4.0
-    PASSED -  Module Name: Automake/1.16.1-GCCcore-8.3.0
-    PASSED -  Module Name: Bison/3.0.4
-    PASSED -  Module Name: Bison/3.0.4-GCCcore-6.4.0
-    PASSED -  Module Name: Bison/3.0.4-GCCcore-7.1.0
-    PASSED -  Module Name: Bison/3.0.4-GCCcore-8.1.0
-    PASSED -  Module Name: Bison/3.0.5
-    PASSED -  Module Name: Bison/3.0.5-GCCcore-6.4.0
-    PASSED -  Module Name: Bison/3.0.5-GCCcore-8.1.0
-    PASSED -  Module Name: Bison/3.2.2-GCCcore-7.4.0
-    PASSED -  Module Name: Bison/3.3.2
-    PASSED -  Module Name: Bison/3.3.2-GCCcore-8.3.0
+    PASSED -  Module Name: Automake/1.16.1-GCCcore-8.3.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Automake/1.16.1-GCCcore-8.3.0.lua )
+    PASSED -  Module Name: Automake/1.15.1-GCCcore-6.4.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Automake/1.15.1-GCCcore-6.4.0.lua )
+    PASSED -  Module Name: Bison/3.0.5 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Bison/3.0.5.lua )
+    PASSED -  Module Name: Bison/3.0.4-GCCcore-7.1.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Bison/3.0.4-GCCcore-7.1.0.lua )
+    PASSED -  Module Name: Bison/3.0.4 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Bison/3.0.4.lua )
+    PASSED -  Module Name: Bison/3.3.2 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Bison/3.3.2.lua )
+    PASSED -  Module Name: Bison/3.2.2-GCCcore-7.4.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Bison/3.2.2-GCCcore-7.4.0.lua )
+    PASSED -  Module Name: Bison/3.0.4-GCCcore-6.4.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Bison/3.0.4-GCCcore-6.4.0.lua )
+    PASSED -  Module Name: Bison/3.0.4-GCCcore-8.1.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Bison/3.0.4-GCCcore-8.1.0.lua )
+    PASSED -  Module Name: Bison/3.0.5-GCCcore-6.4.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Bison/3.0.5-GCCcore-6.4.0.lua )
+    PASSED -  Module Name: Bison/3.3.2-GCCcore-8.3.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Bison/3.3.2-GCCcore-8.3.0.lua )
+    PASSED -  Module Name: Bison/3.0.5-GCCcore-8.1.0 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/Bison/3.0.5-GCCcore-8.1.0.lua )
+
 
 Note, when you use ``name`` it will test all modules with the name ``Automake`` and ``Bison`` found in all module trees.
 If you would like to filter and include by a full canonical name you can specify the ``include`` option. Shown below
@@ -127,8 +131,7 @@ we will only test module ``CUDA/10.0.130``.
     >>> h = ModuleLoadTest("/mxg-hpc/users/ssi29/easybuild/modules/all",include=["CUDA/10.0.130"])
     Testing the Following Module Trees: /mxg-hpc/users/ssi29/easybuild/modules/all
     ________________________________________________________________________________
-    PASSED -  Module Name: CUDA/10.0.130
-
+    PASSED -  Module Name: CUDA/10.0.130 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/CUDA/10.0.130.lua )
 
 Likewise, we can exclude module by full canonical name using the ``exclude`` argument which is a list of module names. In
 example below we test the module tree ``"/usr/share/lmod/lmod/modulefiles/Core"`` which comes with ``lmod`` and ``settarg``
@@ -139,11 +142,23 @@ typically found when installing Lmod. In the second example we exclude ``lmod`` 
     >>> a = ModuleLoadTest("/usr/share/lmod/lmod/modulefiles/Core")
     Testing the Following Module Trees: /usr/share/lmod/lmod/modulefiles/Core
     ________________________________________________________________________________
-    PASSED -  Module Name: lmod
-    PASSED -  Module Name: settarg
+    PASSED -  Module Name: lmod ( modulefile=/usr/share/lmod/lmod/modulefiles/Core/lmod.lua )
+    PASSED -  Module Name: settarg ( modulefile=/usr/share/lmod/lmod/modulefiles/Core/settarg.lua )
 
     >>> b = ModuleLoadTest("/usr/share/lmod/lmod/modulefiles/Core",exclude=["lmod"])
     Testing the Following Module Trees: /usr/share/lmod/lmod/modulefiles/Core
     ________________________________________________________________________________
-    PASSED -  Module Name: settarg
+    PASSED -  Module Name: settarg ( modulefile=/usr/share/lmod/lmod/modulefiles/Core/settarg.lua )
+
+
+If you pass ``include`` and ``exclude`` to *ModuleLoadTest*, then *include* will take precedence and *exclude*
+list will be ignored. Since these are mutually exclusive options use either arguments but don't use both at same time.
+
+.. code-block:: python
+
+    >>> a = ModuleLoadTest(include=["CUDA/10.0.130","Bison/3.0.4"],exclude=["lmod"])
+    Testing the Following Module Trees: /mxg-hpc/users/ssi29/easybuild-HMNS/modules/all/Core:/mxg-hpc/users/ssi29/spack/modules/linux-rhel7-x86_64/Core:/mxg-hpc/users/ssi29/easybuild/modules/all:/etc/modulefiles:/usr/share/modulefiles:/usr/share/modulefiles/Linux:/usr/share/modulefiles/Core:/usr/share/lmod/lmod/modulefiles/Core
+    ________________________________________________________________________________
+    PASSED -  Module Name: Bison/3.0.4 ( modulefile=/mxg-hpc/users/ssi29/easybuild-HMNS/modules/all/Core/Bison/3.0.4.lua )
+    PASSED -  Module Name: CUDA/10.0.130 ( modulefile=/mxg-hpc/users/ssi29/easybuild/modules/all/CUDA/10.0.130.lua )
 

--- a/docs/spider.rst
+++ b/docs/spider.rst
@@ -48,14 +48,27 @@ You can get all module trees used by spider command using the method ``get_trees
 
 Retrieve all Module Names
 --------------------------
-We can retrieve a list of full canonical module names by using ``get_modules()`` method.
+
+We can retrieve a list of full canonical module names by using ``get_modules()`` method. The output is returned as a
+dictionary with key representing the modulefile and value is the full canonical module name.
 
 .. code-block:: python
 
-    >>> c = Spider("/mxg-hpc/users/ssi29/spack/modules/linux-rhel7-x86_64/Core")
-    >>> c.get_modules()
-    ['bzip2/1.0.8-etzfbao', 'diffutils/3.7-jthvt3v', 'gdbm/1.18.1-r4vohzu', 'gettext/0.20.1-c4ovdd2', 'libiconv/1.16-xcmzb6a', 'libpciaccess/0.13.5-cavw42z', 'libsigsegv/2.12-oywfhvk', 'libtool/2.4.6-swiq7rt', 'libxml2/2.9.9-azmlgc5', 'm4/1.4.18-dipchcn', 'ncurses/6.1-3jjw2re', 'pkgconf/1.6.3-oqak6dh', 'readline/8.0-bp7xnfp', 'tar/1.32-gem5z6s', 'util-macros/1.19.1-s4xjvop', 'xz/5.2.4-lvajsnj', 'zlib/1.2.11-zolwez4']
+    >>> >>> b = Spider("/usr/share/lmod/lmod/modulefiles/Core")
+    >>> b.get_modules()
+    {'/usr/share/lmod/lmod/modulefiles/Core/lmod.lua': 'lmod', '/usr/share/lmod/lmod/modulefiles/Core/settarg.lua': 'settarg'}
 
+
+You may filter result by module name (i.e result from ``get_names()``) when using ``get_modules()``. For instance
+if you want to see all ``CUDA`` and ``lmod`` modules you can do the following
+
+.. code-block:: python
+
+    >>> c = Spider()
+    >>> c.get_modules(["lmod","CUDA"])
+    {'/mxg-hpc/users/ssi29/easybuild/modules/all/CUDA/10.0.130.lua': 'CUDA/10.0.130', '/mxg-hpc/users/ssi29/easybuild/modules/all/CUDA/9.2.148.1.lua': 'CUDA/9.2.148.1', '/usr/share/lmod/lmod/modulefiles/Core/lmod.lua': 'lmod'}
+
+.. Note:: You must pass values as a list when filtering by module names
 
 Retrieve all Parent Modules
 ----------------------------

--- a/lmod/moduleloadtest.py
+++ b/lmod/moduleloadtest.py
@@ -59,7 +59,7 @@ class ModuleLoadTest:
         filter_modules = None
 
         spider_cmd = Spider(self.tree)
-        modules = spider_cmd.get_modules(self.name)
+        module_dict, modules = spider_cmd.get_modules(self.name), list(spider_cmd.get_modules(self.name).values())
 
         if self.include:
             filter_modules = set(self.include).intersection(modules)
@@ -79,10 +79,15 @@ class ModuleLoadTest:
             )
             ret = module_cmd.test_modules()
 
+            # extract modulefile based on module name. This is basically getting the key from dictionary (module_dict)
+            # This is only used for printing purposes since it helps to know which module is tested. Simply putting
+            # the full module canonical name is not enough.
+            modulefile = list(module_dict.keys())[list(module_dict.values()).index(module_name)]
+
             if ret == 0:
-                print(f"PASSED -  Module Name: {module_name} ")
+                print(f"PASSED -  Module Name: {module_name} ( modulefile={modulefile} )")
             else:
-                print(f"FAILED -  Module Name: {module_name} ")
+                print(f"FAILED -  Module Name: {module_name} ( modulefile={modulefile} )")
 
             modulecount += 1
 

--- a/lmod/spider.py
+++ b/lmod/spider.py
@@ -46,10 +46,10 @@ class Spider:
         """Retrieve all module names from all module tree.
 
         :return: returns  a sorted list of all full canonical module name from all spider records.
-        :rtype: list
+        :rtype: dict
         """
 
-        module_names = []
+        module_names = {}
 
         for module in self.get_names(name):
             for mpath in self.spider_content[module].keys():
@@ -58,9 +58,9 @@ class Spider:
                 if module_version.startswith(".version") or module_version.startswith(".modulerc"):
                     continue
 
-                module_names.append(self.spider_content[module][mpath]["fullName"])
+                module_names[mpath]=self.spider_content[module][mpath]["fullName"]
 
-        return sorted(module_names)
+        return module_names
 
     def get_parents(self):
         """Return all parent modules from all spider trees. This will search all ``parentAA`` keys in spider

--- a/tests/test_spider.py
+++ b/tests/test_spider.py
@@ -15,7 +15,7 @@ class TestSpider:
         assert b.get_trees() == tree
 
     def test_get_names(self):
-        """Retrieve unique software and modules from Spider class."""
+        """Retrieve unique software from Spider class."""
 
         a = Spider()
         # the return type is expected to be a list
@@ -24,8 +24,15 @@ class TestSpider:
         # The Travis build should have lmod module that should be available
         assert "lmod" in a.get_names()
 
+    def test_get_modules(self):
+        """This test will retrieve full canonical module names from ``get_modules`` method which is expected to return a
+        dictionary"""
+        a = Spider()
         # this will return the full canonical module name which should be a list.
-        assert isinstance(a.get_modules(), list)
+        assert isinstance(a.get_modules(), dict)
 
+    def test_get_parents(self):
+        """This will retrieve all parent modules. The method ``get_parents`` is expected to return of type list"""
+        a = Spider()
         parent_modules = a.get_parents()
         assert isinstance(parent_modules, list)


### PR DESCRIPTION
This PR will allow the following
  - Change return type of ``Spider().get_modules()`` from list to dict and add modulefile as key and value is module name
  - Print modulefile name in ``ModuleLoadTest`` 
  - Update docs for Spider and ModuleLoadTest section
  - Fix regression test due to change in ``get_modules`` method
  - Update API docs 
  - Import LMODULE_VERSION in conf.py to make sure doc version is in sync when we change version